### PR TITLE
feat: update library for prettier@2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 node_modules
 dist
 coverage
+.idea

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "minimist": ">=1.2.2"
   },
   "dependencies": {
-    "@types/prettier": "^1.19.0",
+    "@types/prettier": "^2.0.0",
     "import-sort": "^6.0.0",
     "import-sort-config": "^6.0.0",
     "import-sort-parser-typescript": "^6.0.0",
@@ -66,7 +66,7 @@
     "conventional-changelog-conventionalcommits": "^4.2.3",
     "husky": "^4.2.3",
     "lint-staged": "^10.0.8",
-    "prettier": "^1.19.1",
+    "prettier": "^2.0.0",
     "prettier-plugin-packagejson": "^2.0.10",
     "semantic-release": "^17.0.4",
     "tsdx": "^0.12.3",
@@ -74,7 +74,7 @@
     "typescript": "^3.8.3"
   },
   "peerDependencies": {
-    "prettier": "^1.19.1"
+    "prettier": "^2.0.0"
   },
   "importSort": {
     ".js,.ts,.tsx": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import sortImports from 'import-sort';
 import { IConfigByGlobs, getConfig } from 'import-sort-config';
 import { Plugin } from 'prettier';
-import { parsers as javascriptParsers } from 'prettier/parser-babylon';
+import { parsers as javascriptParsers } from 'prettier/parser-babel';
 import { parsers as typescriptParsers } from 'prettier/parser-typescript';
 import invariant from 'tiny-invariant';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1341,10 +1341,10 @@
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
-"@types/prettier@^1.19.0":
-  version "1.19.0"
-  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-1.19.0.tgz#a2502fb7ce9b6626fdbfc2e2a496f472de1bdd05"
-  integrity sha512-gDE8JJEygpay7IjA/u3JiIURvwZW08f0cZSZLAzFoX/ZmeqvS0Sqv+97aKuHpNsalAMMhwPe+iAS6fQbfmbt7A==
+"@types/prettier@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.0.0.tgz#dc85454b953178cc6043df5208b9e949b54a3bc4"
+  integrity sha512-/rM+sWiuOZ5dvuVzV37sUuklsbg+JPOP8d+nNFlo2ZtfpzPiPvh1/gc8liWOLBqe+sR+ZM7guPaIcTt6UZTo7Q==
 
 "@types/resolve@0.0.8":
   version "0.0.8"
@@ -7236,6 +7236,11 @@ prettier@^1.19.1:
   version "1.19.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
   integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
+
+prettier@^2.0.0:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.5.tgz#d6d56282455243f2f92cc1716692c08aa31522d4"
+  integrity sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==
 
 pretty-format@^24.9.0:
   version "24.9.0"


### PR DESCRIPTION
## Description

Fixes #1 

When used with Prettier ^2.0.0, the library won't work because of the following error:

```
Error: Cannot find module 'prettier/parser-babylon'
```

As @elyesbenabdelkader pointed out in #1 , Prettier now uses `parser-babel` from version 2. These changes:
- update prettier dependency version to `^2.0.0`
- fix parser import from `parser-babylon` to `parser-babel`

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project and `yarn lint --fix` runs successfully.
- [x] I have updated the documentation where necessary.
- [x] New code is unit tested and all current tests pass when running `yarn test` .
